### PR TITLE
CAM: CircularHoleBase - Fix onDocumentRestored

### DIFF
--- a/src/Mod/CAM/Path/Op/CircularHoleBase.py
+++ b/src/Mod/CAM/Path/Op/CircularHoleBase.py
@@ -259,7 +259,7 @@ class ObjectOp(PathOp.ObjectOp):
         obj.Disabled = []
 
     def onDocumentRestored(self, obj):
-        super().onDocumentRestored(obj)
+        self.opOnDocumentRestored(obj)
         # Migration logic for SortingMode
         if not hasattr(obj, "SortingMode"):
             obj.addProperty(

--- a/src/Mod/CAM/Path/Op/Drilling.py
+++ b/src/Mod/CAM/Path/Op/Drilling.py
@@ -91,7 +91,7 @@ class ObjectDrilling(PathCircularHoleBase.ObjectOp):
         """circularHoleFeatures(obj) ... drilling works on anything, turn on all Base geometries and Locations."""
         return PathOp.FeatureBaseGeometry | PathOp.FeatureLocations | PathOp.FeatureCoolant
 
-    def onDocumentRestored(self, obj):
+    def opOnDocumentRestored(self, obj):
         if hasattr(obj, "chipBreakEnabled"):
             obj.renameProperty("chipBreakEnabled", "ChipBreakEnabled")
         elif not hasattr(obj, "ChipBreakEnabled"):


### PR DESCRIPTION
Probably we should use regular method `onDocumentRestored()` from `Path.Op.CircularHoleBase` and call **op***OnDocumentRestored()* from operations (Drilling, Helix, Tapping, ThreadMilling) if needed

---

**Tapping** and **ThreadMilling** operations not contains migration code,  so no problem there


**Helix** operation already contains **op***OnDocumentRestored()* - is Ok

https://github.com/Connor9220/FreeCAD/blob/ecbe21ca03a59723c90ce5a677ae7ccea06ebc12/src/Mod/CAM/Path/Op/Helix.py#L193

**Drilling** operation overwrites `onDocumentRestored()` - **is not Ok**

https://github.com/Connor9220/FreeCAD/blob/ecbe21ca03a59723c90ce5a677ae7ccea06ebc12/src/Mod/CAM/Path/Op/Drilling.py#L94

---

After this commit I checked migration for Drilling, Helix, Tapping and ThreadMilling operations from 1.1 to 1.2 and it working fine