### PR TITLE
fix onDocumentRestored

### DIFF
--- a/src/Mod/CAM/Path/Op/CircularHoleBase.py
+++ b/src/Mod/CAM/Path/Op/CircularHoleBase.py
@@ -272,7 +272,7 @@ class ObjectOp(PathOp.ObjectOp):
         obj.Disabled = []
 
     def onDocumentRestored(self, obj):
-        self.opOnDocumentRestored(obj)
+        super().onDocumentRestored(obj)
         # Migration logic for SortingMode
         if not hasattr(obj, "SortingMode"):
             obj.addProperty(


### PR DESCRIPTION
Get error while open old document, because missed property `BlockDelete`
Probably we should not forget to call `onDocumentRestored()` from `Path.Op.Base`

For `Helix` everything should be good, but I am not sure about `Drilling`
Should we call `onDocumentRestored()`  from `Path.Op.Base` for `Drilling`???
Because `Drilling` overrides `onDocumentRestored()` from the beginning

https://github.com/Connor9220/FreeCAD/blob/4ac848aab06af222d79e4928702699e81189f10a/src/Mod/CAM/Path/Op/Drilling.py#L99

I checked the work after this PR and everything looks good, but I'm not sure I fully understand all the logic