### PR TITLE
SetupPropertiesLinking

### DIFF
--- a/src/Mod/CAM/Path/Op/Base.py
+++ b/src/Mod/CAM/Path/Op/Base.py
@@ -1217,3 +1217,10 @@ def getCycleTimeEstimate(obj):
     cycleTime = time.strftime("%H:%M:%S", time.gmtime(seconds))
 
     return cycleTime
+
+
+def SetupPropertiesLinking():
+    setup = []
+    setup.append("CollisionAvoidanceStrategy")
+    setup.append("CollisionClearance")
+    return setup

--- a/src/Mod/CAM/Path/Op/Deburr.py
+++ b/src/Mod/CAM/Path/Op/Deburr.py
@@ -427,11 +427,9 @@ class ObjectDeburr(PathEngraveBase.ObjectOp):
 
 
 def SetupProperties():
-    setup = []
+    setup = PathOp.SetupPropertiesLinking()
     setup.append("Width")
     setup.append("ExtraDepth")
-    setup.append("CollisionAvoidanceStrategy")
-    setup.append("CollisionClearance")
     return setup
 
 

--- a/src/Mod/CAM/Path/Op/Drilling.py
+++ b/src/Mod/CAM/Path/Op/Drilling.py
@@ -568,7 +568,7 @@ class ObjectDrilling(PathCircularHoleBase.ObjectOp):
 
 
 def SetupProperties():
-    setup = []
+    setup = PathOp.SetupPropertiesLinking()
     setup.append("Strategy")
     setup.append("PeckDepth")
     setup.append("PeckEnabled")
@@ -577,8 +577,6 @@ def SetupProperties():
     setup.append("AddTipLength")
     setup.append("ExtraOffset")
     setup.append("KeepToolDown")
-    setup.append("CollisionAvoidanceStrategy")
-    setup.append("CollisionClearance")
     return setup
 
 

--- a/src/Mod/CAM/Path/Op/Engrave.py
+++ b/src/Mod/CAM/Path/Op/Engrave.py
@@ -198,7 +198,9 @@ class ObjectEngrave(PathEngraveBase.ObjectOp):
 
 
 def SetupProperties():
-    return ["StartVertex", "CollisionAvoidanceStrategy", "CollisionClearance"]
+    setup = PathOp.SetupPropertiesLinking()
+    setup.append("StartVertex")
+    return setup
 
 
 def Create(name, obj=None, parentJob=None):

--- a/src/Mod/CAM/Path/Op/Helix.py
+++ b/src/Mod/CAM/Path/Op/Helix.py
@@ -917,7 +917,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
 
 def SetupProperties():
     """Returns property names for which the "Setup Sheet" should provide defaults."""
-    setup = []
+    setup = PathOp.SetupPropertiesLinking()
     setup.append("CutMode")
     setup.append("StartAt")
     setup.append("StepOver")

--- a/src/Mod/CAM/Path/Op/MillFacing.py
+++ b/src/Mod/CAM/Path/Op/MillFacing.py
@@ -713,7 +713,7 @@ def Create(name, obj=None, parentJob=None):
 
 def SetupProperties():
     """SetupProperties() ... Return list of properties required for the operation."""
-    setup = []
+    setup = PathOp.SetupPropertiesLinking()
     setup.append("CutMode")
     setup.append("ClearingPattern")
     setup.append("Angle")


### PR DESCRIPTION
Suggest to not add linking properties directly in `SetupProperties()` of each operation
Lets use common method `SetupPropertiesLinking` from `Path.Op.Base`

The same way uses in **Profile** and **PocketBase**

https://github.com/Connor9220/FreeCAD/blob/95260fa27b02dead658a3999585de55df7bb9eac/src/Mod/CAM/Path/Op/PocketBase.py#L344-L353